### PR TITLE
feat: change Viacep API to Brasil API

### DIFF
--- a/src/app/commands/CepCommand.ts
+++ b/src/app/commands/CepCommand.ts
@@ -17,11 +17,11 @@ export default class EconomyCommand {
 
     try {
       const { data }: IResponse = await axios.get<IServerData>(
-        `https://viacep.com.br/ws/${setCep}/json/unicode/`
+        `https://brasilapi.com.br/api/cep/v1/${setCep}`
       );
 
       return msg.reply(
-        `*CEP*: ${data.cep}\n*Logradouro*: ${data.logradouro}\n*Bairro*: ${data.bairro}\n*UF*: ${data.uf}`
+        `*CEP*: ${data.cep}\n*Logradouro*: ${data.street}\n*Bairro*: ${data.neighborhood}\n*UF*: ${data.state}`
       );
     } catch (error) {
       return msg.reply(`CEP não localizado!`);

--- a/src/app/interfaces/Cep.ts
+++ b/src/app/interfaces/Cep.ts
@@ -4,9 +4,10 @@ interface IResponse {
 
 interface IServerData {
   cep: string;
-  logradouro: string;
-  bairro: string;
-  uf: string;
+  state: string;
+  city: string;
+  neighborhood: string;
+  street: string;
 }
 
 export { IResponse, IServerData };


### PR DESCRIPTION
I think it would be good to change from Viacep API to BrasilAPI.
BrasilAPI uses Viacep and the Correios API to fetch the cep, if one of the api fails, the BrasilAPI search on the other.